### PR TITLE
Feat user story 15 and 16/eli

### DIFF
--- a/app/controllers/cars_controller.rb
+++ b/app/controllers/cars_controller.rb
@@ -1,6 +1,6 @@
 class CarsController < ApplicationController
   def index
-    @cars = Car.all
+    @cars = Car.all.where(available_for_lease: true)
   end
 
   def edit

--- a/app/controllers/dealership_cars_controller.rb
+++ b/app/controllers/dealership_cars_controller.rb
@@ -1,7 +1,7 @@
 class DealershipCarsController < ApplicationController
   def index
     @dealership = Dealership.find(params[:id])
-    @cars = @dealership.cars
+    @cars = @dealership.cars.order(:make)
   end
 
   def new

--- a/spec/features/cars/index_spec.rb
+++ b/spec/features/cars/index_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Cars Index Page", type: :feature do
   before :each do
     @dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
     @car_1 = @dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000)
-    @car_2 = @dealership.cars.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, dealer_id: 1, price: 19500)
+    @car_2 = @dealership.cars.create!(make: "BMW", model: "440i", year: 2019, miles: 35000, available_for_lease: true, dealer_id: 1, price: 23000)
     @car_3 = @dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, dealer_id: 1, price: 28000)
   end
 
@@ -40,12 +40,21 @@ RSpec.describe "Cars Index Page", type: :feature do
 
         expect(current_path).to eq("/cars")
       end
+
       it 'has a link to /dealerships' do
         visit "/cars"
         click_on "Dealerships Index"
 
         expect(current_path).to eq("/dealerships")
       end
+    end
+
+    it "only shows cas in the index with where the Available For Lease is 'true'" do
+      car_4 = Car.create!(make: "Toyota", model: "Hilux", year: 1998, miles: 350000, available_for_lease: false, dealer_id: 1, price: 8500, dealership: @dealership)
+
+      visit "/cars"
+
+      expect(page).to_not have_content("Hilux")
     end
   end
 end

--- a/spec/features/dealerships/cars/index_spec.rb
+++ b/spec/features/dealerships/cars/index_spec.rb
@@ -43,4 +43,16 @@ RSpec.describe "Dealership Cars Index", type: :feature do
       end
     end
   end
+
+  it 'sorts inventory by make alphabetically' do
+    dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
+    car_1 = dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, dealer_id: 1, price: 28000)
+    car_2 = dealership.cars.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, dealer_id: 1, price: 19500)
+    car_3 = dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000)
+
+    visit "/dealerships/#{dealership.id}/cars"
+
+    expect("Audi").to appear_before("BMW")
+    expect("BMW").to appear_before("Mercedes-Benz")
+  end
 end


### PR DESCRIPTION
User Story 15, Child Index only shows `true` Records 

As a visitor
When I visit the child index
Then I only see records where the boolean column is `true`

User Story 16, Sort Parent's Children in Alphabetical Order by name 

As a visitor
When I visit the Parent's children Index Page
Then I see a link to sort children in alphabetical order
When I click on the link
I'm taken back to the Parent's children Index Page where I see all of the parent's children in alphabetical order