### PR TITLE
Feat it2 usability/eli

### DIFF
--- a/app/views/cars/index.html.erb
+++ b/app/views/cars/index.html.erb
@@ -2,9 +2,12 @@
 <%= link_to "Dealerships Index", "/dealerships" %>
 <h1>Cars</h1>
 <% @cars.each do |car| %>
-<h2><%= car.make %></h2>
-<h3>Model: <%= car.model %></h3>
-<h4>Year: <%= car.year %></h4>
+<p>
+<b><%= car.make %></b>
+<%= link_to  "Edit Vehicle", "/cars/#{car.id}/edit"%>
+<p>
+<p>Model: <%= car.model %></p>
+<p>Year: <%= car.year %></p>
 <p>Miles: <%= car.miles %></p>
 <p>Leasing Options? <%= car.available_for_lease%></p>
 <p> Located at: <%= car.dealership.dealername %></p>

--- a/app/views/dealerships/index.html.erb
+++ b/app/views/dealerships/index.html.erb
@@ -6,6 +6,7 @@
   <p>
     <b><%= link_to dealership.dealername, "/dealerships/#{dealership.id}"%></b>
       Created at: <%= dealership.created_at %>
+      <%= link_to "Edit #{dealership.dealername}", "/dealerships/#{dealership.id}/edit"%>
   </p>
 <% end %>
 

--- a/spec/features/cars/index_spec.rb
+++ b/spec/features/cars/index_spec.rb
@@ -56,5 +56,11 @@ RSpec.describe "Cars Index Page", type: :feature do
 
       expect(page).to_not have_content("Hilux")
     end
+
+    it "can edit Cars from the index page" do
+      visit "/cars"
+
+      expect(page).to have_link("Edit Vehicle")
+    end
   end
 end

--- a/spec/features/dealerships/index_spec.rb
+++ b/spec/features/dealerships/index_spec.rb
@@ -50,5 +50,17 @@ RSpec.describe "Dealerships Index Page", type: :feature do
         expect(current_path).to eq("/dealerships/#{@dealership_1.id}")
       end
     end
+
+    it 'can update dealerships from the Dealership Index' do
+      dealership_1 = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
+      dealership_2 = Dealership.create!(city: "Aurora", dealername: "Shirley's Premier Used Cars", number_of_stars_rating: 5, lease_program: true)
+      dealership_3 = Dealership.create!(city: "Boulder", dealername: "Becky's Autorama", number_of_stars_rating: 5, lease_program: true)
+
+      visit "/dealerships"
+
+      expect(page).to have_link("Edit #{dealership_1.dealername}")
+      expect(page).to have_link("Edit #{dealership_2.dealername}")
+      expect(page).to have_link("Edit #{dealership_3.dealername}")
+    end
   end
 end


### PR DESCRIPTION
User Story 17, Parent Update From Parent Index Page 

As a visitor
When I visit the parent index page
Next to every parent, I see a link to edit that parent's info
When I click the link
I should be taken to that parent's edit page where I can update its information just like in User Story 12

User Story 18, Child Update From Childs Index Page 

As a visitor
When I visit the `child_table_name` index page or a parent `child_table_name` index page
Next to every child, I see a link to edit that child's info
When I click the link
I should be taken to that `child_table_name` edit page where I can update its information just like in User Story 14