### PR TITLE
Feat parent and child delete/eli

### DIFF
--- a/app/controllers/cars_controller.rb
+++ b/app/controllers/cars_controller.rb
@@ -17,6 +17,12 @@ class CarsController < ApplicationController
     @car = Car.find(params[:id])
    end
 
+   def destroy
+    car = Car.find(params[:id])
+    car.destroy
+    redirect_to "/cars"
+   end
+
    private
    def car_params
     params.permit(:make, :model, :year, :miles, :available_for_lease, :dealer_id, :price)

--- a/app/controllers/dealerships_controller.rb
+++ b/app/controllers/dealerships_controller.rb
@@ -26,6 +26,10 @@ class DealershipsController < ApplicationController
   end
 
   def destroy
+    dealership = Dealership.find(params[:id])
+    dealership.cars.destroy_all
+    dealership.destroy
+    redirect_to "/dealerships"
   end
 
   def most_recently_created_first(dealerships)

--- a/app/views/cars/index.html.erb
+++ b/app/views/cars/index.html.erb
@@ -4,6 +4,7 @@
 <% @cars.each do |car| %>
 <p>
 <b><%= car.make %></b>
+<%= link_to "Show", "/cars/#{car.id}" %>
 <%= link_to  "Edit Vehicle", "/cars/#{car.id}/edit"%>
 <p>
 <p>Model: <%= car.model %></p>

--- a/app/views/cars/show.html.erb
+++ b/app/views/cars/show.html.erb
@@ -9,3 +9,4 @@
 <h4>Price: <%= "$#{@car.price}" %></h4>
 
 <%= link_to "Edit Vehicle", "/cars/#{@car.id}/edit" %>
+<%= button_to "Delete", "/cars/#{@car.id}", method: :delete %>

--- a/app/views/dealerships/show.html.erb
+++ b/app/views/dealerships/show.html.erb
@@ -6,5 +6,5 @@
 <p>Leasing Available? <%= @dealership.lease_program %></p>
 <p>Total Number of Vehicles in Inventory: <%= @dealership.counting_cars %></p>
 <%= link_to "Dealership Inventory", "/dealerships/#{@dealership.id}/cars" %>
-
 <%= link_to "Edit Dealership", "/dealerships/#{@dealership.id}/edit" %>
+<%= link_to "Delete Dealership", "/dealerships", method: :delete %>

--- a/app/views/dealerships/show.html.erb
+++ b/app/views/dealerships/show.html.erb
@@ -7,4 +7,4 @@
 <p>Total Number of Vehicles in Inventory: <%= @dealership.counting_cars %></p>
 <%= link_to "Dealership Inventory", "/dealerships/#{@dealership.id}/cars" %>
 <%= link_to "Edit Dealership", "/dealerships/#{@dealership.id}/edit" %>
-<%= link_to "Delete Dealership", "/dealerships", method: :delete %>
+<%= button_to "Delete Dealership", "/dealerships/#{@dealership.id}", method: :delete %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
 
   get '/dealerships/:id/edit', to: 'dealerships#edit'
   patch '/dealerships/:id', to: 'dealerships#update'
-  # delete '/dealerships/:id', to: 'dealerships#destroy'
+  delete '/dealerships/:id', to: 'dealerships#destroy'
 
   get '/cars', to: 'cars#index'
   get '/cars/:id', to: 'cars#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   get '/cars/:id', to: 'cars#show'
   get '/cars/:id/edit', to: 'cars#edit'
   patch '/cars/:id', to: 'cars#update'
-  # delete '/cars/:id', to: "cars#destroy"
+  delete '/cars/:id', to: 'cars#destroy'
 
   get '/dealerships/:id/cars', to: 'dealership_cars#index'
   get '/dealerships/:id/cars/new', to: 'dealership_cars#new'

--- a/spec/features/cars/destroy_spec.rb
+++ b/spec/features/cars/destroy_spec.rb
@@ -2,9 +2,26 @@ require 'rails_helper'
 
 RSpec.describe "Destroy" do
   describe "As a visitor" do
+    before :each do
+      @dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
+      @car_1 = @dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000)
+      @car_2 = @dealership.cars.create!(make: "BMW", model: "440i", year: 2019, miles: 35000, available_for_lease: true, dealer_id: 1, price: 23000)
+      @car_3 = @dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, dealer_id: 1, price: 28000)
+    end
     describe "When I visit a car show page" do
       it "Has a button to delete the car" do
+        visit "/cars/#{@car_2.id}"
 
+        expect(page).to have_button("Delete")
+      end
+
+      it "deletes the Dealership when clicked and redirects to '/dealerships'" do
+        visit "/cars/#{@car_2.id}"
+
+        click_button "Delete"
+
+        expect(current_path).to eq("/cars")
+        expect("/cars").to_not have_content(@car_2)
       end
     end
   end

--- a/spec/features/cars/destroy_spec.rb
+++ b/spec/features/cars/destroy_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe "Destroy" do
+  describe "As a visitor" do
+    describe "When I visit a car show page" do
+      it "Has a button to delete the car" do
+
+      end
+    end
+  end
+end

--- a/spec/features/cars/index_spec.rb
+++ b/spec/features/cars/index_spec.rb
@@ -62,5 +62,11 @@ RSpec.describe "Cars Index Page", type: :feature do
 
       expect(page).to have_link("Edit Vehicle")
     end
+
+    it "links to a Car's Show page" do
+      visit '/cars'
+
+      expect(page).to have_link("Show")
+    end
   end
 end

--- a/spec/features/dealerships/destroy_spec.rb
+++ b/spec/features/dealerships/destroy_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "Destroy" do
+  describe "As a visitor" do
+    describe "When I visit a dealership show page" do
+      it "Has a link to delete the dealership" do
+        dealership_1 = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
+        dealership_2 = Dealership.create!(city: "Aurora", dealername: "Shirley's Premier Used Cars", number_of_stars_rating: 5, lease_program: true)
+        dealership_3 = Dealership.create!(city: "Boulder", dealername: "Becky's Autorama", number_of_stars_rating: 5, lease_program: true)
+
+        visit "/dealerships/#{dealership_1.id}"
+
+        expect(page).to have_link("Delete Dealership")
+      end
+    end
+  end
+end

--- a/spec/features/dealerships/destroy_spec.rb
+++ b/spec/features/dealerships/destroy_spec.rb
@@ -10,7 +10,20 @@ RSpec.describe "Destroy" do
 
         visit "/dealerships/#{dealership_1.id}"
 
-        expect(page).to have_link("Delete Dealership")
+        expect(page).to have_button("Delete Dealership")
+      end
+
+      it "deletes the Dealership when clicked and redirects to '/dealerships'" do
+        dealership_1 = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
+        dealership_2 = Dealership.create!(city: "Aurora", dealername: "Shirley's Premier Used Cars", number_of_stars_rating: 5, lease_program: true)
+        dealership_3 = Dealership.create!(city: "Boulder", dealername: "Becky's Autorama", number_of_stars_rating: 5, lease_program: true)
+        visit "/dealerships/#{dealership_1.id}"
+
+        click_button "Delete Dealership"
+
+        expect(current_path).to eq("/dealerships")
+        expect(page).to_not have_content(dealership_1)
+
       end
     end
   end

--- a/spec/features/dealerships/destroy_spec.rb
+++ b/spec/features/dealerships/destroy_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Destroy" do
   describe "As a visitor" do
     describe "When I visit a dealership show page" do
-      it "Has a link to delete the dealership" do
+      it "Has a button to delete the dealership" do
         dealership_1 = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
         dealership_2 = Dealership.create!(city: "Aurora", dealername: "Shirley's Premier Used Cars", number_of_stars_rating: 5, lease_program: true)
         dealership_3 = Dealership.create!(city: "Boulder", dealername: "Becky's Autorama", number_of_stars_rating: 5, lease_program: true)

--- a/spec/features/dealerships/show_spec.rb
+++ b/spec/features/dealerships/show_spec.rb
@@ -1,12 +1,3 @@
-# [ ] done
-
-# User Story 2, Parent Show
-
-# As a visitor
-# When I visit '/parents/:id'
-# Then I see the parent with that id including the parent's attributes
-# (data from each column that is on the parent table)
-
 require "rails_helper"
 
 RSpec.describe "Dealership Show Page", type: :feature do


### PR DESCRIPTION
User Story 19, Parent Delete 

As a visitor
When I visit a parent show page
Then I see a link to delete the parent
When I click the link "Delete Parent"
Then a 'DELETE' request is sent to '/parents/:id',
the parent is deleted, and all child records are deleted
and I am redirected to the parent index page where I no longer see this parent

User Story 20, Child Delete 

As a visitor
When I visit a child show page
Then I see a link to delete the child "Delete Child"
When I click the link
Then a 'DELETE' request is sent to '/child_table_name/:id',
the child is deleted,
and I am redirected to the child index page where I no longer see this child