### PR TITLE
Feat it3 active record/eli

### DIFF
--- a/app/controllers/dealership_cars_controller.rb
+++ b/app/controllers/dealership_cars_controller.rb
@@ -5,6 +5,11 @@ class DealershipCarsController < ApplicationController
     if params[:sort_by_make] == "true"
       @cars = @dealership.cars.order(:make)
     end
+
+    if params[:miles_threshold] != nil
+      miles = params[:miles_threshold]
+      @cars = @cars.miles_threshold(miles)
+    end
   end
 
   def new

--- a/app/controllers/dealership_cars_controller.rb
+++ b/app/controllers/dealership_cars_controller.rb
@@ -1,7 +1,10 @@
 class DealershipCarsController < ApplicationController
   def index
     @dealership = Dealership.find(params[:id])
-    @cars = @dealership.cars.order(:make)
+    @cars = @dealership.cars
+    if params[:sort_by_make] == "true"
+      @cars = @dealership.cars.order(:make)
+    end
   end
 
   def new

--- a/app/models/car.rb
+++ b/app/models/car.rb
@@ -1,3 +1,8 @@
 class Car < ApplicationRecord
   belongs_to :dealership
+
+  def self.miles_threshold(integer)
+    self.where("miles > #{integer}")
+  end
+
 end

--- a/app/views/cars/edit.html.erb
+++ b/app/views/cars/edit.html.erb
@@ -9,10 +9,7 @@
 <%= form.text_field :miles %>
 <%= form.label "Available for lease?(true/false)" %>
 <%= form.text_field :available_for_lease %>
-<%= form.label "Dealer id(Serves no purpose. Put any integer)" %>
-<%= form.text_field :dealer_id %>
 <%= form.label "Price" %>
 <%= form.text_field :price %>
-
 <%= form.submit "Update Vehicle" %>
 <% end %>

--- a/app/views/dealership_cars/index.html.erb
+++ b/app/views/dealership_cars/index.html.erb
@@ -1,4 +1,8 @@
 <%= link_to "Back to Dealership", "/dealerships/#{@dealership.id}" %>
+<br>
+<br>
+<%= button_to "Sort By Make", "/dealerships/#{@dealership.id}/cars", method: :get, params: {sort_by_make: true} %>
+
 <% @cars.each do |car| %>
 <h2><%= car.make %></h2>
 <h3>Model: <%= car.model %></h3>

--- a/app/views/dealership_cars/index.html.erb
+++ b/app/views/dealership_cars/index.html.erb
@@ -5,7 +5,7 @@
 <br>
 <%= form_with url: "/dealerships/#{@dealership.id}/cars", method: :get, local: true do |form| %>
 <%= form.label  "Display Cars Over A Given Mile Threshold" %>
-<%= form.text_field :miles %>
+<%= form.text_field :miles_threshold %>
 <%= form.submit "Show" %>
 <% end %>
 <br>

--- a/app/views/dealership_cars/index.html.erb
+++ b/app/views/dealership_cars/index.html.erb
@@ -2,7 +2,13 @@
 <br>
 <br>
 <%= button_to "Sort By Make", "/dealerships/#{@dealership.id}/cars", method: :get, params: {sort_by_make: true} %>
-
+<br>
+<%= form_with url: "/dealerships/#{@dealership.id}/cars", method: :get, local: true do |form| %>
+<%= form.label  "Display Cars Over A Given Mile Threshold" %>
+<%= form.text_field :miles %>
+<%= form.submit "Show" %>
+<% end %>
+<br>
 <% @cars.each do |car| %>
 <h2><%= car.make %></h2>
 <h3>Model: <%= car.model %></h3>

--- a/app/views/dealership_cars/new.html.erb
+++ b/app/views/dealership_cars/new.html.erb
@@ -9,8 +9,6 @@
 <%= form.text_field :miles %>
 <%= form.label "Available for lease?(true/false)" %>
 <%= form.text_field :available_for_lease %>
-<%= form.label "Dealer id(Serves no purpose. Put any integer)" %>
-<%= form.text_field :dealer_id %>
 <%= form.label "Price" %>
 <%= form.text_field :price %>
 

--- a/app/views/dealerships/show.html.erb
+++ b/app/views/dealerships/show.html.erb
@@ -7,4 +7,6 @@
 <p>Total Number of Vehicles in Inventory: <%= @dealership.counting_cars %></p>
 <%= link_to "Dealership Inventory", "/dealerships/#{@dealership.id}/cars" %>
 <%= link_to "Edit Dealership", "/dealerships/#{@dealership.id}/edit" %>
+<br>
+<br>
 <%= button_to "Delete Dealership", "/dealerships/#{@dealership.id}", method: :delete %>

--- a/db/migrate/20221012021214_create_cars.rb
+++ b/db/migrate/20221012021214_create_cars.rb
@@ -1,7 +1,6 @@
 class CreateCars < ActiveRecord::Migration[5.2]
   def change
     create_table :cars do |t|
-      t.integer :dealer_id
       t.string :make
       t.string :model
       t.integer :year

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,6 @@ ActiveRecord::Schema.define(version: 2022_10_13_183101) do
   enable_extension "plpgsql"
 
   create_table "cars", force: :cascade do |t|
-    t.integer "dealer_id"
     t.string "make"
     t.string "model"
     t.integer "year"

--- a/spec/features/cars/destroy_spec.rb
+++ b/spec/features/cars/destroy_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe "Destroy" do
   describe "As a visitor" do
     before :each do
       @dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
-      @car_1 = @dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000)
-      @car_2 = @dealership.cars.create!(make: "BMW", model: "440i", year: 2019, miles: 35000, available_for_lease: true, dealer_id: 1, price: 23000)
-      @car_3 = @dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, dealer_id: 1, price: 28000)
+      @car_1 = @dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, price: 37000)
+      @car_2 = @dealership.cars.create!(make: "BMW", model: "440i", year: 2019, miles: 35000, available_for_lease: true, price: 23000)
+      @car_3 = @dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, price: 28000)
     end
     describe "When I visit a car show page" do
       it "Has a button to delete the car" do

--- a/spec/features/cars/edit_spec.rb
+++ b/spec/features/cars/edit_spec.rb
@@ -1,16 +1,3 @@
-# [ ] done
-
-# User Story 14, Child Update
-
-# As a visitor
-# When I visit a Child Show page
-# Then I see a link to update that Child "Update Child"
-# When I click the link
-# I am taken to '/child_table_name/:id/edit' where I see a form to edit the child's attributes:
-# When I click the button to submit the form "Update Child"
-# Then a `PATCH` request is sent to '/child_table_name/:id',
-# the child's data is updated,
-# and I am redirected to the Child Show page where I see the Child's updated information
 require 'rails_helper'
 
 RSpec.describe "Car Update" do
@@ -18,7 +5,7 @@ RSpec.describe "Car Update" do
     describe "When I visit a Car Show page" do
       it "Then I see a link to update that car 'Update Vehicle'" do
         dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
-        car_1 = Car.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000, dealership: dealership)
+        car_1 = Car.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, price: 37000, dealership: dealership)
 
         visit "/cars/#{car_1.id}"
         expect(page).to have_link("Edit Vehicle")
@@ -26,7 +13,7 @@ RSpec.describe "Car Update" do
       describe "When I click the link" do
         it "I am taken '/cars/id/edit'" do
           dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
-          car_1 = Car.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000, dealership: dealership)
+          car_1 = Car.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, price: 37000, dealership: dealership)
           visit "/cars/#{car_1.id}"
 
           click_link "Edit Vehicle"
@@ -37,7 +24,6 @@ RSpec.describe "Car Update" do
           expect(page).to have_content("Year")
           expect(page).to have_content("Miles")
           expect(page).to have_content("Available for lease?(true/false)")
-          expect(page).to have_content("Dealer id(serves no purpose. put any integer)")
           expect(page).to have_content("Price")
           expect(page).to have_button("Update Vehicle")
         end
@@ -46,7 +32,7 @@ RSpec.describe "Car Update" do
       describe "When I fill out the form and click 'Update Vehicle'" do
         it "the vehicle attributes are updated and I am redirected to the cars index" do
           dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
-          car_1 = Car.create!(make: "Subaroo", model: "WRX", year: 2030, miles: 16000, available_for_lease: true, dealer_id: 1, price: 7000, dealership: dealership)
+          car_1 = Car.create!(make: "Subaroo", model: "WRX", year: 2030, miles: 16000, available_for_lease: true, price: 7000, dealership: dealership)
           visit "/cars/#{car_1.id}"
 
           expect(page).to have_content("Subaroo")
@@ -63,7 +49,6 @@ RSpec.describe "Car Update" do
           fill_in(:year, with: 2020)
           fill_in(:miles, with: 22000)
           fill_in(:available_for_lease, with: true)
-          fill_in(:dealer_id, with: 1)
           fill_in(:price, with: 26000)
 
           click_button "Update Vehicle"

--- a/spec/features/cars/index_spec.rb
+++ b/spec/features/cars/index_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe "Cars Index Page", type: :feature do
   before :each do
     @dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
-    @car_1 = @dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000)
-    @car_2 = @dealership.cars.create!(make: "BMW", model: "440i", year: 2019, miles: 35000, available_for_lease: true, dealer_id: 1, price: 23000)
-    @car_3 = @dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, dealer_id: 1, price: 28000)
+    @car_1 = @dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, price: 37000)
+    @car_2 = @dealership.cars.create!(make: "BMW", model: "440i", year: 2019, miles: 35000, available_for_lease: true, price: 23000)
+    @car_3 = @dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, price: 28000)
   end
 
   describe "As a visitor" do
@@ -50,7 +50,7 @@ RSpec.describe "Cars Index Page", type: :feature do
     end
 
     it "only shows cas in the index with where the Available For Lease is 'true'" do
-      car_4 = Car.create!(make: "Toyota", model: "Hilux", year: 1998, miles: 350000, available_for_lease: false, dealer_id: 1, price: 8500, dealership: @dealership)
+      car_4 = Car.create!(make: "Toyota", model: "Hilux", year: 1998, miles: 350000, available_for_lease: false, price: 8500, dealership: @dealership)
 
       visit "/cars"
 

--- a/spec/features/cars/show_spec.rb
+++ b/spec/features/cars/show_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe "Car Show Page", type: :feature do
     describe "When I visit '/cars/:id'" do
       before :each do
         @dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
-        @car_1 = @dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000)
-        @car_2 = @dealership.cars.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, dealer_id: 1, price: 19500)
-        @car_3 = @dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, dealer_id: 1, price: 28000)
+        @car_1 = @dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, price: 37000)
+        @car_2 = @dealership.cars.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, price: 19500)
+        @car_3 = @dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, price: 28000)
       end
 
       it "Then I see the child with that id including the child's attributes" do

--- a/spec/features/dealerships/cars/index_spec.rb
+++ b/spec/features/dealerships/cars/index_spec.rb
@@ -77,5 +77,14 @@ RSpec.describe "Dealership Cars Index", type: :feature do
       expect(page).to have_content("Display cars over a given mile threshold")
       expect(page).to have_button("Show")
     end
+
+    it "Displays cars with more miles than the given threshold" do
+      visit "/dealerships/#{@dealership.id}/cars"
+      fill_in(:miles_threshold, with: 20000)
+
+      click_button "Show"
+
+      expect(page).to_not have_content(@car_3)
+    end
   end
 end

--- a/spec/features/dealerships/cars/index_spec.rb
+++ b/spec/features/dealerships/cars/index_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe "Dealership Cars Index", type: :feature do
     describe "When I visit '/dealerships/:id/cars" do
       before :each do
         @dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
-        @car_1 = @dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000)
-        @car_2 = @dealership.cars.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, dealer_id: 1, price: 19500)
-        @car_3 = @dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, dealer_id: 1, price: 28000)
+        @car_1 = @dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, price: 37000)
+        @car_2 = @dealership.cars.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, price: 19500)
+        @car_3 = @dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, price: 28000)
         visit "/dealerships/#{@dealership.id}/cars"
       end
 
@@ -46,9 +46,9 @@ RSpec.describe "Dealership Cars Index", type: :feature do
 
   it 'sorts inventory by make alphabetically' do
     dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
-    car_1 = dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, dealer_id: 1, price: 28000)
-    car_2 = dealership.cars.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, dealer_id: 1, price: 19500)
-    car_3 = dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000)
+    car_1 = dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, price: 28000)
+    car_2 = dealership.cars.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, price: 19500)
+    car_3 = dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, price: 37000)
 
     visit "/dealerships/#{dealership.id}/cars"
 
@@ -66,9 +66,9 @@ RSpec.describe "Dealership Cars Index", type: :feature do
   describe "Display Records Over a Given Threshold " do
     before :each do
       @dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
-      @car_1 = @dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, dealer_id: 1, price: 28000)
-      @car_2 = @dealership.cars.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, dealer_id: 1, price: 19500)
-      @car_3 = @dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000)
+      @car_1 = @dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, price: 28000)
+      @car_2 = @dealership.cars.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, price: 19500)
+      @car_3 = @dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, price: 37000)
     end
 
     it 'has button that allows the user to input a number value' do

--- a/spec/features/dealerships/cars/index_spec.rb
+++ b/spec/features/dealerships/cars/index_spec.rb
@@ -62,4 +62,20 @@ RSpec.describe "Dealership Cars Index", type: :feature do
     expect("Audi").to appear_before("BMW")
     expect("BMW").to appear_before("Mercedes-Benz")
   end
+
+  describe "Display Records Over a Given Threshold " do
+    before :each do
+      @dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
+      @car_1 = @dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, dealer_id: 1, price: 28000)
+      @car_2 = @dealership.cars.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, dealer_id: 1, price: 19500)
+      @car_3 = @dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000)
+    end
+
+    it 'has button that allows the user to input a number value' do
+      visit "/dealerships/#{@dealership.id}/cars"
+
+      expect(page).to have_content("Display cars over a given mile threshold")
+      expect(page).to have_button("Show")
+    end
+  end
 end

--- a/spec/features/dealerships/cars/index_spec.rb
+++ b/spec/features/dealerships/cars/index_spec.rb
@@ -52,6 +52,13 @@ RSpec.describe "Dealership Cars Index", type: :feature do
 
     visit "/dealerships/#{dealership.id}/cars"
 
+    expect("Mercedes-Benz").to appear_before("BMW")
+    expect("BMW").to appear_before('Audi')
+
+    expect(page).to have_button("Sort By Make")
+
+    click_button "Sort By Make"
+
     expect("Audi").to appear_before("BMW")
     expect("BMW").to appear_before("Mercedes-Benz")
   end

--- a/spec/features/dealerships/cars/new_spec.rb
+++ b/spec/features/dealerships/cars/new_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe "Dealership Car Creation" do
     describe "When I visit a Dealership Inventory Index page" do
       it "Then I see a link to add a new car to the inventory for that dealership 'Add Vehicle'" do
         dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
-        car_1 = Car.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000, dealership: dealership)
-        car_2 = Car.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, dealer_id: 1, price: 19500, dealership: dealership)
-        car_3 = Car.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, dealer_id: 1, price: 28000, dealership: dealership)
+        car_1 = Car.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, price: 37000, dealership: dealership)
+        car_2 = Car.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, price: 19500, dealership: dealership)
+        car_3 = Car.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, price: 28000, dealership: dealership)
 
         visit "/dealerships/#{dealership.id}/cars"
 
@@ -18,9 +18,9 @@ RSpec.describe "Dealership Car Creation" do
       describe "When I click the link" do
         it "I am take to '/dealerships/:id/cars/new' where I see a form to add a new vehicle" do
           dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
-          car_1 = Car.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000, dealership: dealership)
-          car_2 = Car.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, dealer_id: 1, price: 19500, dealership: dealership)
-          car_3 = Car.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, dealer_id: 1, price: 28000, dealership: dealership)
+          car_1 = Car.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, price: 37000, dealership: dealership)
+          car_2 = Car.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, price: 19500, dealership: dealership)
+          car_3 = Car.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, price: 28000, dealership: dealership)
 
           expect(dealership.cars).to eq([car_1, car_2, car_3])
           visit "/dealerships/#{dealership.id}/cars"
@@ -33,7 +33,6 @@ RSpec.describe "Dealership Car Creation" do
           expect(page).to have_content("Year")
           expect(page).to have_content("Miles")
           expect(page).to have_content("Available for lease?(true/false)")
-          expect(page).to have_content("Dealer id(serves no purpose. put any integer)")
           expect(page).to have_content("Price")
           expect(page).to have_button("Create Vehicle")
         end
@@ -42,9 +41,9 @@ RSpec.describe "Dealership Car Creation" do
       describe "When  I fill out the form with the vehicles attributes and click 'Create Vehicle'" do
         it "A new vehicle is created and I am redirected to the dealerships inventory page" do
           dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
-          car_1 = Car.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000, dealership: dealership)
-          car_2 = Car.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, dealer_id: 1, price: 19500, dealership: dealership)
-          car_3 = Car.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, dealer_id: 1, price: 28000, dealership: dealership)
+          car_1 = Car.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, price: 37000, dealership: dealership)
+          car_2 = Car.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, price: 19500, dealership: dealership)
+          car_3 = Car.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, price: 28000, dealership: dealership)
           visit "/dealerships/#{dealership.id}/cars/new"
 
           fill_in(:make, with: "Porsche")
@@ -52,7 +51,6 @@ RSpec.describe "Dealership Car Creation" do
           fill_in(:year, with: 2020)
           fill_in(:miles, with: 7500)
           fill_in(:available_for_lease, with: true)
-          fill_in(:dealer_id, with: 2345)
           fill_in(:price, with: 63000)
 
           click_button "Create Vehicle"

--- a/spec/features/dealerships/show_spec.rb
+++ b/spec/features/dealerships/show_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe "Dealership Show Page", type: :feature do
       end
 
       it "shows the total number of vehicles in inventory" do
-        @car_1 = @dealership_1.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000)
-        @car_2 = @dealership_1.cars.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, dealer_id: 1, price: 19500)
-        @car_3 = @dealership_1.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, dealer_id: 1, price: 28000)
+        @car_1 = @dealership_1.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, price: 37000)
+        @car_2 = @dealership_1.cars.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, price: 19500)
+        @car_3 = @dealership_1.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, price: 28000)
 
         visit "dealerships/#{@dealership_1.id}"
         expect(page).to have_content("Total Number of Vehicles in Inventory")

--- a/spec/models/car_spec.rb
+++ b/spec/models/car_spec.rb
@@ -1,5 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe Car, type: :model do
-  it {should belong_to :dealership}
+  describe "Belong" do
+    it {should belong_to :dealership}
+  end
+
+  describe "#miles_threshold" do
+    it "return cars over the given threshold" do
+      dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
+      car_1 = Car.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000, dealership: dealership)
+      car_2 = Car.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, dealer_id: 1, price: 19500, dealership: dealership)
+      car_3 = Car.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, dealer_id: 1, price: 28000, dealership: dealership)
+
+      expect(dealership.cars.miles_threshold(20000)).to eq([car_2, car_3])
+    end
+  end
 end

--- a/spec/models/car_spec.rb
+++ b/spec/models/car_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Car, type: :model do
   describe "#miles_threshold" do
     it "return cars over the given threshold" do
       dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
-      car_1 = Car.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000, dealership: dealership)
-      car_2 = Car.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, dealer_id: 1, price: 19500, dealership: dealership)
-      car_3 = Car.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, dealer_id: 1, price: 28000, dealership: dealership)
+      car_1 = Car.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, price: 37000, dealership: dealership)
+      car_2 = Car.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, price: 19500, dealership: dealership)
+      car_3 = Car.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, price: 28000, dealership: dealership)
 
       expect(dealership.cars.miles_threshold(20000)).to eq([car_2, car_3])
     end

--- a/spec/models/dealership_spec.rb
+++ b/spec/models/dealership_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe Dealership, type: :model do
  describe 'instance methods' do
   before :each do
     @dealership = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
-    @car_1 = @dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, dealer_id: 1, price: 37000)
-    @car_2 = @dealership.cars.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, dealer_id: 1, price: 19500)
-    @car_3 = @dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, dealer_id: 1, price: 28000)
+    @car_1 = @dealership.cars.create!(make: "Audi", model: "A4", year: 2020, miles: 16000, available_for_lease: true, price: 37000)
+    @car_2 = @dealership.cars.create!(make: "BMW", model: "440i", year: 2017, miles: 51000, available_for_lease: false, price: 19500)
+    @car_3 = @dealership.cars.create!(make: "Mercedes-Benz", model: "C300", year: 2019, miles: 24000, available_for_lease: true, price: 28000)
   end
   it 'counts the total number of cars in the dealership' do
     expect(@dealership.counting_cars).to eq(3)


### PR DESCRIPTION
Remove dealer_id attribute.

Fix sort alphabetically so it is called by a button


User Story 21, Display Records Over a Given Threshold 

As a visitor
When I visit the Parent's children Index Page
I see a form that allows me to input a number value
When I input a number value and click the submit button that reads 'Only return records with more than `number` of `column_name`'
Then I am brought back to the current index page with only the records that meet that threshold shown.