### PR TITLE
Create ability to delete dealerships and caars from their respective …

### DIFF
--- a/app/views/cars/index.html.erb
+++ b/app/views/cars/index.html.erb
@@ -13,4 +13,5 @@
 <p>Leasing Options? <%= car.available_for_lease%></p>
 <p> Located at: <%= car.dealership.dealername %></p>
 <h4>Price: <%= "$#{car.price}" %></h4>
+<%= button_to "Delete This #{car.make}", "/cars/#{car.id}", method: :delete %>
 <% end %>

--- a/app/views/dealerships/index.html.erb
+++ b/app/views/dealerships/index.html.erb
@@ -7,7 +7,10 @@
     <b><%= link_to dealership.dealername, "/dealerships/#{dealership.id}"%></b>
       Created at: <%= dealership.created_at %>
       <%= link_to "Edit #{dealership.dealername}", "/dealerships/#{dealership.id}/edit"%>
+      <%= button_to "Delete #{dealership.dealername}", "/dealerships/#{dealership.id}", method: :delete %>
   </p>
 <% end %>
 
 <%= link_to "New Dealership", "/dealerships/new" %>
+
+

--- a/spec/features/cars/destroy_spec.rb
+++ b/spec/features/cars/destroy_spec.rb
@@ -23,6 +23,19 @@ RSpec.describe "Destroy" do
         expect(current_path).to eq("/cars")
         expect("/cars").to_not have_content(@car_2)
       end
+
+      it "Can delete vehicles from the Cars Index page" do
+        visit '/cars'
+
+        expect(page).to have_button("Delete This #{@car_1.make}")
+        expect(page).to have_button("Delete This #{@car_2.make}")
+        expect(page).to have_button("Delete This #{@car_3.make}")
+
+        click_button "Delete This #{@car_2.make}"
+
+        expect(current_path).to eq("/cars")
+        expect(page).to_not have_content(@car_2)
+      end
     end
   end
 end

--- a/spec/features/dealerships/destroy_spec.rb
+++ b/spec/features/dealerships/destroy_spec.rb
@@ -27,4 +27,23 @@ RSpec.describe "Destroy" do
       end
     end
   end
+
+  describe "When I visit the Dealership's index page" do
+    it "Has a button  that can Delete dealerships from the Dealership Index page" do
+      dealership_1 = Dealership.create!(city: "Denver", dealername: "Eli's Used Car Palace", number_of_stars_rating: 3, lease_program: true)
+      dealership_2 = Dealership.create!(city: "Aurora", dealername: "Shirley's Premier Used Cars", number_of_stars_rating: 5, lease_program: true)
+      dealership_3 = Dealership.create!(city: "Boulder", dealername: "Becky's Autorama", number_of_stars_rating: 5, lease_program: true)
+
+      visit "/dealerships"
+
+      expect(page).to have_button("Delete #{dealership_1.dealername}")
+      expect(page).to have_button("Delete #{dealership_2.dealername}")
+      expect(page).to have_button("Delete #{dealership_3.dealername}")
+
+      click_button "Delete #{dealership_1.dealername}"
+
+      expect(current_path).to eq("/dealerships")
+      expect(page).to_not have_content("Eli's Used Car Palace")
+    end
+  end
 end


### PR DESCRIPTION
User Story 22, Parent Delete From Parent Index Page 

As a visitor
When I visit the parent index page
Next to every parent, I see a link to delete that parent
When I click the link
I am returned to the Parent Index Page where I no longer see that parent

User Story 23, Child Delete From Childs Index Page 

As a visitor
When I visit the `child_table_name` index page or a parent `child_table_name` index page
Next to every child, I see a link to delete that child
When I click the link
I should be taken to the `child_table_name` index page where I no longer see that child
